### PR TITLE
Allow empty explanation and clarification

### DIFF
--- a/lib/aida/message.ex
+++ b/lib/aida/message.ex
@@ -86,6 +86,14 @@ defmodule Aida.Message do
   def respond(message, response) do
     response = interpolate_expressions(message, response)
     response = interpolate_vars(message, response)
+    add_reply(message, response)
+  end
+
+  defp add_reply(message, "") do
+    message
+  end
+
+  defp add_reply(message, response) do
     %{message | reply: message.reply ++ [response]}
   end
 

--- a/priv/schema.json
+++ b/priv/schema.json
@@ -112,8 +112,8 @@
         "type": {"enum": ["keyword_responder"]},
         "id": {"$ref": "#/definitions/non_empty_string"},
         "name": {"$ref": "#/definitions/non_empty_string"},
-        "explanation": {"$ref": "#/definitions/localized_string"},
-        "clarification": {"$ref": "#/definitions/localized_string"},
+        "explanation": {"$ref": "#/definitions/localized_string_or_empty"},
+        "clarification": {"$ref": "#/definitions/localized_string_or_empty"},
         "keywords": {"$ref": "#/definitions/localized_keywords"},
         "response": {"$ref": "#/definitions/localized_string"},
         "relevant": {"$ref": "#/definitions/non_empty_string"}
@@ -298,8 +298,8 @@
         "type": {"enum": ["decision_tree"]},
         "id": {"$ref": "#/definitions/non_empty_string"},
         "name": {"$ref": "#/definitions/non_empty_string"},
-        "explanation": {"$ref": "#/definitions/localized_string"},
-        "clarification": {"$ref": "#/definitions/localized_string"},
+        "explanation": {"$ref": "#/definitions/localized_string_or_empty"},
+        "clarification": {"$ref": "#/definitions/localized_string_or_empty"},
         "keywords": {"$ref": "#/definitions/localized_keywords"},
         "relevant": {"$ref": "#/definitions/non_empty_string"},
         "tree": {"$ref": "#/definitions/tree_question"}

--- a/test/aida/json_schema_test.exs
+++ b/test/aida/json_schema_test.exs
@@ -11,6 +11,7 @@ defmodule Aida.JsonSchemaTest do
   @valid_base_64_key ~s("ZWNjYzIwNGMtYmExNS00Y2M5LWI5YTMtMjJiOTg0ZDc5YThl")
   @invalid_base_64_key ".."
   @valid_localized_string ~s({"en": "a"})
+  @valid_empty_localized_string ~s({"en": "a"})
   @valid_message ~s({"message" : #{@valid_localized_string}})
   @valid_front_desk ~s({
     "greeting": #{@valid_message},
@@ -24,8 +25,8 @@ defmodule Aida.JsonSchemaTest do
     "type": "keyword_responder",
     "id" : "1",
     "name" : "a",
-    "explanation": #{@valid_localized_string},
-    "clarification": #{@valid_localized_string},
+    "explanation": #{@valid_empty_localized_string},
+    "clarification": #{@valid_empty_localized_string},
     "keywords": #{@valid_localized_keywords},
     "response": #{@valid_localized_string}
   })
@@ -142,8 +143,8 @@ defmodule Aida.JsonSchemaTest do
     "type": "decision_tree",
     "id": "2a516ba3-2e7b-48bf-b4c0-9b8cd55e003f",
     "name": "Food menu",
-    "explanation": #{@valid_localized_string},
-    "clarification": #{@valid_localized_string},
+    "explanation": #{@valid_empty_localized_string},
+    "clarification": #{@valid_empty_localized_string},
     "keywords": #{@valid_localized_keywords},
     "tree": {
       "question": #{@valid_localized_string},


### PR DESCRIPTION
For keyword responders and decision trees (fixes #135)