### PR TITLE
 Support facebook callbacks for an specific bot

### DIFF
--- a/lib/aida/message.ex
+++ b/lib/aida/message.ex
@@ -25,7 +25,7 @@ defmodule Aida.Message do
     new(content, bot, session, DateTime.utc_now)
   end
 
-  @spec new(content :: String.t, bot :: Bot.t, session :: Session.t) :: t
+  @spec new(content :: String.t, bot :: Bot.t, session :: Session.t, timestamp :: DateTime.t) :: t
   def new(content, %Bot{} = bot, session, timestamp) do
     %Message{
       session: session,

--- a/lib/aida_web/controllers/callback_controller.ex
+++ b/lib/aida_web/controllers/callback_controller.ex
@@ -1,6 +1,10 @@
 defmodule AidaWeb.CallbackController do
   use AidaWeb, :controller
 
+  def callback(conn, %{"provider" => "facebook", "bot_id" => bot_id}) do
+    Aida.Channel.Facebook.callback(conn, bot_id)
+  end
+
   def callback(conn, %{"provider" => "facebook"}) do
     Aida.Channel.Facebook.callback(conn)
   end

--- a/lib/aida_web/router.ex
+++ b/lib/aida_web/router.ex
@@ -48,6 +48,7 @@ defmodule AidaWeb.Router do
     pipe_through :browser
     get "/callback/:provider", CallbackController, :callback
     post "/callback/:provider", CallbackController, :callback
+    post "/callback/:provider/:bot_id", CallbackController, :callback
     get "/content/image/:uuid", ImageController, :image
   end
 

--- a/test/aida/channels/facebook_test.exs
+++ b/test/aida/channels/facebook_test.exs
@@ -1,15 +1,41 @@
 defmodule Aida.Channel.FacebookTest do
   alias Aida.Channel.Facebook
-  alias Aida.{Channel, ChannelRegistry}
+  alias Aida.{Channel, ChannelRegistry, DB, BotParser, BotManager}
   use ExUnit.Case
+  use Aida.DataCase
+  use Phoenix.ConnTest
 
   @bot_id "986a4b66-b3a0-40d5-83b2-c535427dc0f9"
   @page_id "1234567890"
 
   setup do
-    Facebook.init
     ChannelRegistry.start_link
+    BotManager.start_link
     :ok
+  end
+
+  describe "with bot" do
+    setup do
+      manifest = File.read!("test/fixtures/valid_manifest_single_lang.json") |> Poison.decode!
+      {:ok, db_bot} = DB.create_bot(%{manifest: manifest})
+      {:ok, bot} = BotParser.parse(db_bot.id, manifest)
+      BotManager.start(bot)
+      [bot: bot]
+    end
+
+    test "looking for channel in nonexistent bot returns :not_found" do
+      assert Facebook.find_channel_for_page_id(@page_id, "nonexistent") == :not_found
+    end
+
+    test "looking for not registered channel in bot returns :not_found", %{bot: bot} do
+      assert Facebook.find_channel_for_page_id("notregistered", bot.id) == :not_found
+    end
+
+    test "looking for registered channel for specific bot returns channel", %{bot: bot} do
+      channel = Facebook.find_channel_for_page_id(@page_id, bot.id)
+      assert channel.bot_id == bot.id
+      assert channel.page_id == @page_id
+    end
   end
 
   test "looking for non registered channel returns :not_found" do

--- a/test/fixtures/valid_manifest_single_lang_same_page_id.json
+++ b/test/fixtures/valid_manifest_single_lang_same_page_id.json
@@ -1,0 +1,95 @@
+{
+  "version": "1",
+  "languages": ["en"],
+  "notifications_url": "https://example.com/some/notification/endpoint",
+  "front_desk": {
+    "greeting": {
+      "message": {
+        "en": "Hello, I'm not a Restaurant bot"
+      }
+    },
+    "introduction": {
+      "message": {
+        "en": "I can do a number of different things"
+      }
+    },
+    "not_understood": {
+      "message": {
+        "en": "Sorry, I didn't understand that"
+      }
+    },
+    "clarification": {
+      "message": {
+        "en": "I'm not sure exactly what you need."
+      }
+    },
+    "unsubscribe": {
+      "introduction_message": {
+        "message": {
+          "en": "Send UNSUBSCRIBE to stop receiving messages"
+        }
+      },
+      "keywords": {
+        "en": ["UNSUBSCRIBE"]
+      },
+      "acknowledge_message": {
+        "message": {
+          "en": "I won't send you any further messages"
+        }
+      }
+    },
+    "threshold": 0.2
+  },
+  "skills": [
+    {
+      "type": "keyword_responder",
+      "id": "this is a string id",
+      "name": "Food menu",
+      "explanation": {
+        "en": "I can give you information about our menu"
+      },
+      "clarification": {
+        "en": "For menu options, write 'menu'"
+      },
+      "keywords": {
+        "en": ["menu","food"]
+      },
+      "response": {
+        "en": "We have {food_options}"
+      }
+    },
+    {
+      "type": "keyword_responder",
+      "id": "this is a different id",
+      "name": "Opening hours",
+      "explanation": {
+        "en": "I can give you information about our opening hours"
+      },
+      "clarification": {
+        "en": "For opening hours say 'hours'"
+      },
+      "keywords": {
+        "en": ["hours","time"]
+      },
+      "response": {
+        "en": "We are open every day from 7pm to 11pm"
+      }
+    }
+  ],
+  "variables": [
+    {
+      "name": "food_options",
+      "values": {
+        "en": "barbecue and pasta"
+      }
+    }
+  ],
+  "channels": [
+    {
+      "type": "facebook",
+      "page_id": "1234567890",
+      "verify_token": "qwertyuiopasdfghjklzxcvbnm",
+      "access_token": "QWERTYUIOPASDFGHJKLZXCVBNM"
+    }
+  ]
+}


### PR DESCRIPTION
And fallback to the previous behaviour when bot_id is not provided.

For #167