### PR TITLE
Parse multilingual training_sentences

### DIFF
--- a/priv/schema.json
+++ b/priv/schema.json
@@ -560,15 +560,15 @@
 
     "localized_sentences": {
       "type": "object",
-       "properties": {
-        "en": {
+      "patternProperties": {
+        "^[a-z]{2,3}$": {
           "type": "array",
           "minItems": 1,
           "items": {"$ref": "#/definitions/non_empty_string"}
         }
       },
-      "additionalProperties": false,
-      "required": ["en"]
+      "minProperties": 1,
+      "additionalProperties": false
     },
 
     "localized_keywords": {

--- a/test/aida/json_schema_test.exs
+++ b/test/aida/json_schema_test.exs
@@ -1028,4 +1028,27 @@ defmodule Aida.JsonSchemaTest do
       :manifest_v1
     )
   end
+
+  test "multiple languages in training_sentences" do
+    manifest = ~s({
+      "channels": [],
+      "front_desk": #{@valid_front_desk},
+      "languages": ["en", "es"],
+      "notifications_url": "valid url",
+      "skills": [
+        {
+          "clarification": {"en": "a", "es": "a"},
+          "explanation": {"en": "a", "es": "a"},
+          "id": "1",
+          "name": "Keyword responder",
+          "response": {"en": "a", "es": "a"},
+          "training_sentences": {"en": ["a"], "es": ["a"]},
+          "type": "keyword_responder"
+        }
+      ],
+      "variables": [],
+      "version": "1"
+    })
+    assert_valid(manifest, :manifest_v1)
+  end
 end


### PR DESCRIPTION
In order to allow wit_ai monolingualism validation in BotParser

For #247